### PR TITLE
update for compatibility with miniupnpc API version 14 and newer

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1061,10 +1061,14 @@ void ThreadMapPort()
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* API version >= 14 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
makes bitmark compatible with latest version of libminiupnpc (2.0 at this moment)