### PR TITLE
Compatibility fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -200,7 +200,7 @@ case $host in
   *mingw*)
 
      #pkgconfig does more harm than good with MinGW
-     use_pkgconfig=no
+     use_pkgconfig=yes
 
      TARGET_OS=windows
      AC_CHECK_LIB([mingwthrd],      [main],, AC_MSG_ERROR(lib missing))
@@ -233,18 +233,11 @@ case $host in
        AC_MSG_WARN("makensis not found. Cannot create installer.")
      fi
 
-     AC_CHECK_PROG([CYGPATH], [cygpath], yes, no)
-     if test x$CYGPATH = xno; then
-       AC_MSG_WARN("cygpath not found.")
-     else
-       WINPATH_TOPSRCDIR=$(cygpath --windows $(realpath $srcdir))
-       WINPATH_INSTALLPREFIX=$(cygpath --windows $prefix)
-       WINPATH_MINGWHOSTPREFIX=$(cygpath --windows "/usr/$host/")
+     WINPATH_TOPSRCDIR=$(realpath $srcdir)
+     WINPATH_INSTALLPREFIX=$prefix
 
-       AC_SUBST(WINPATH_TOPSRCDIR)
-       AC_SUBST(WINPATH_INSTALLPREFIX)
-       AC_SUBST(WINPATH_MINGWHOSTPREFIX)
-     fi
+     AC_SUBST(WINPATH_TOPSRCDIR)
+     AC_SUBST(WINPATH_INSTALLPREFIX)
 
      AC_PATH_TOOL(WINDRES, windres, none)
      if test x$WINDRES = xnone; then
@@ -609,7 +602,7 @@ AM_CONDITIONAL([BUILD_BITMARK_CLI], [test x$build_bitmark_cli = xyes])
 AC_MSG_RESULT($build_bitmark_cli)
 
 dnl sets $bitmark_enable_qt, $bitmark_enable_qt_test, $bitmark_enable_qt_dbus
-BITMARK_QT_CONFIGURE([$use_pkgconfig], [qt4])
+BITMARK_QT_CONFIGURE([$use_pkgconfig], [qt5])
 
 AC_LANG_POP
 

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -10,19 +10,19 @@ SetCompressor /SOLID lzma
 !define URL http://github.com/project-bitmark/bitmark/
 
 # MUI Symbol Definitions
-!define MUI_ICON "@WINPATH_TOPSRCDIR@\share\pixmaps\bitmark.ico"
-!define MUI_WELCOMEFINISHPAGE_BITMAP "@WINPATH_TOPSRCDIR@\share\pixmaps\nsis-wizard.bmp"
+!define MUI_ICON "@WINPATH_TOPSRCDIR@/share/pixmaps/bitmark.ico"
+!define MUI_WELCOMEFINISHPAGE_BITMAP "@WINPATH_TOPSRCDIR@/share/pixmaps/nsis-wizard.bmp"
 !define MUI_HEADERIMAGE
 !define MUI_HEADERIMAGE_RIGHT
-!define MUI_HEADERIMAGE_BITMAP "@WINPATH_TOPSRCDIR@\share\pixmaps\nsis-header.bmp"
+!define MUI_HEADERIMAGE_BITMAP "@WINPATH_TOPSRCDIR@/share/pixmaps/nsis-header.bmp"
 !define MUI_FINISHPAGE_NOAUTOCLOSE
 !define MUI_STARTMENUPAGE_REGISTRY_ROOT HKLM
 !define MUI_STARTMENUPAGE_REGISTRY_KEY ${REGKEY}
 !define MUI_STARTMENUPAGE_REGISTRY_VALUENAME StartMenuGroup
 !define MUI_STARTMENUPAGE_DEFAULTFOLDER "@PACKAGE_NAME@"
-!define MUI_FINISHPAGE_RUN $INSTDIR\bitmark-qt.exe
-!define MUI_UNICON "${NSISDIR}\Contrib\Graphics\Icons\modern-uninstall.ico"
-!define MUI_UNWELCOMEFINISHPAGE_BITMAP "@WINPATH_TOPSRCDIR@\share\pixmaps\nsis-wizard.bmp"
+!define MUI_FINISHPAGE_RUN $INSTDIR/bitmark-qt.exe
+!define MUI_UNICON "${NSISDIR}/Contrib/Graphics/Icons/modern-uninstall.ico"
+!define MUI_UNWELCOMEFINISHPAGE_BITMAP "@WINPATH_TOPSRCDIR@/share/pixmaps/nsis-wizard.bmp"
 !define MUI_UNFINISHPAGE_NOAUTOCLOSE
 
 # Included files
@@ -48,7 +48,7 @@ Var StartMenuGroup
 !insertmacro MUI_LANGUAGE English
 
 # Installer attributes
-OutFile @WINPATH_TOPSRCDIR@\bitmark-${VERSION}-win@WINDOWS_BITS@-setup.exe
+OutFile @WINPATH_TOPSRCDIR@/bitmark-${VERSION}-win@WINDOWS_BITS@-setup.exe
 !if "@WINDOWS_BITS@" == "64"
 InstallDir $PROGRAMFILES64\Bitmark
 !else
@@ -73,51 +73,26 @@ ShowUninstDetails show
 Section -Main SEC0000
     SetOutPath $INSTDIR
     SetOverwrite on
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\iconv.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libboost_chrono-mt.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libboost_filesystem.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libboost_filesystem-mt.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libboost_program_options-mt.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libboost_system.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libboost_system-mt.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libboost_thread-mt.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libbz2-1.dll
-    File @WINPATH_INSTALLPREFIX@\bin\libdb_cxx-4.8.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libeay32.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libfreetype-6.dll
-    !if "@WINDOWS_BITS@" == "64"
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libgcc_s_seh-1.dll
-    !else
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libgcc_s_sjlj-1.dll
-    !endif
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libglib-2.0-0.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libharfbuzz-0.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libintl-8.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libpcre-1.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libpcre2-16-0.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libpng16-16.dll
-    File @WINPATH_INSTALLPREFIX@\bin\libprotobuf-14.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libssp-0.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libstdc++-6.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libwinpthread-1.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\Qt5Core.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\Qt5Gui.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\Qt5Network.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\Qt5Widgets.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\ssleay32.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\zlib1.dll
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\bin\libsodium-23.dll
-    File @WINPATH_INSTALLPREFIX@\bin\bitmark-qt.exe
-    File /oname=COPYING.txt @WINPATH_TOPSRCDIR@\COPYING
-    File /oname=readme.txt @WINPATH_TOPSRCDIR@\doc\README_windows.txt
-    SetOutPath $INSTDIR\daemon
-    File @WINPATH_INSTALLPREFIX@\bin\bitmarkd.exe
-    File @WINPATH_INSTALLPREFIX@\bin\bitmark-cli.exe
-    SetOutPath $INSTDIR\doc
-    File /r @WINPATH_TOPSRCDIR@\doc\*.*
-    SetOutPath $INSTDIR\platforms
-    File @WINPATH_MINGWHOSTPREFIX@\sys-root\mingw\lib\qt5\plugins\platforms\qwindows.dll
-    SetOutPath $INSTDIR
+!include dll_list.nsh
+    File @WINPATH_INSTALLPREFIX@/bin/bitmark-qt.exe
+    File /oname=COPYING.txt @WINPATH_TOPSRCDIR@/COPYING
+    File /oname=readme.txt @WINPATH_TOPSRCDIR@/doc/README_windows.txt
+    File @WINPATH_INSTALLPREFIX@/bin/bitmarkd.exe
+    File @WINPATH_INSTALLPREFIX@/bin/bitmark-cli.exe
+    SetOutPath $INSTDIR/doc
+    File /r @WINPATH_TOPSRCDIR@/doc/*.*
+
+    SetOutPath "$INSTDIR\platforms"
+    File platforms/qdirect2d.dll
+    File platforms/qminimal.dll
+    File platforms/qoffscreen.dll
+    File platforms/qwindows.dll
+    SetOutPath "$INSTDIR\imageformats"
+    File imageformats/qgif.dll
+    File imageformats/qico.dll
+    File imageformats/qjpeg.dll
+    SetOutPath "$INSTDIR"
+
     WriteRegStr HKCU "${REGKEY}\Components" Main 1
 
     # Remove old wxwidgets-based-bitmark executable and locales:
@@ -167,10 +142,11 @@ Section /o -un.Main UNSEC0000
     Delete /REBOOTOK $INSTDIR\*.dll
     Delete /REBOOTOK $INSTDIR\COPYING.txt
     Delete /REBOOTOK $INSTDIR\readme.txt
-    RMDir /r /REBOOTOK $INSTDIR\daemon
     RMDir /r /REBOOTOK $INSTDIR\doc
     Delete /REBOOTOK $INSTDIR\platforms\*.dll
     RMDir /r /REBOOTOK $INSTDIR\platforms
+    Delete /REBOOTOK $INSTDIR\imageformats\*.dll
+    RMDir /r /REBOOTOK $INSTDIR\imageformats
     DeleteRegValue HKCU "${REGKEY}\Components" Main
 SectionEnd
 

--- a/src/cryptonight/crypto/slow-hash.c
+++ b/src/cryptonight/crypto/slow-hash.c
@@ -908,8 +908,7 @@ STATIC INLINE void aes_pseudo_round_xor(const uint8_t *in, uint8_t *out, const u
 void cn_slow_hash(const void *data, size_t length, char *hash, int variant, int prehashed)
 {
     RDATA_ALIGN16 uint8_t expandedKey[240];
-    RDATA_ALIGN16 uint8_t hp_state[MEMORY];
-
+    uint8_t *hp_state = (uint8_t *) malloc(MEMORY);
     uint8_t text[INIT_SIZE_BYTE];
     RDATA_ALIGN16 uint64_t a[2];
     RDATA_ALIGN16 uint64_t b[2];
@@ -993,6 +992,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int variant, int 
     memcpy(state.init, text, INIT_SIZE_BYTE);
     hash_permutation(&state.hs);
     extra_hashes[state.hs.b[0] & 3](&state, 200, hash);
+    free(hp_state);
 }
 #else /* aarch64 && crypto */
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -112,7 +112,7 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
     if (!BN_bin2bn(msg, msglen, e)) { ret=-1; goto err; }
     if (8*msglen > n) BN_rshift(e, e, 8-(n & 7));
     zero = BN_CTX_get(ctx);
-    if (!BN_zero(zero)) { ret=-1; goto err; }
+    BN_zero(zero);
     if (!BN_mod_sub(e, zero, e, order, ctx)) { ret=-1; goto err; }
     rr = BN_CTX_get(ctx);
     ECDSA_SIG_get0(ecsig, (const BIGNUM **)&s, 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,21 +155,21 @@ struct CMainSignals {
 }
 
 void RegisterWallet(CWalletInterface* pwalletIn) {
-    g_signals.SyncTransaction.connect(boost::bind(&CWalletInterface::SyncTransaction, pwalletIn, _1, _2, _3));
-    g_signals.EraseTransaction.connect(boost::bind(&CWalletInterface::EraseFromWallet, pwalletIn, _1));
-    g_signals.UpdatedTransaction.connect(boost::bind(&CWalletInterface::UpdatedTransaction, pwalletIn, _1));
-    g_signals.SetBestChain.connect(boost::bind(&CWalletInterface::SetBestChain, pwalletIn, _1));
-    g_signals.Inventory.connect(boost::bind(&CWalletInterface::Inventory, pwalletIn, _1));
+    g_signals.SyncTransaction.connect(boost::bind(&CWalletInterface::SyncTransaction, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+    g_signals.EraseTransaction.connect(boost::bind(&CWalletInterface::EraseFromWallet, pwalletIn, std::placeholders::_1));
+    g_signals.UpdatedTransaction.connect(boost::bind(&CWalletInterface::UpdatedTransaction, pwalletIn, std::placeholders::_1));
+    g_signals.SetBestChain.connect(boost::bind(&CWalletInterface::SetBestChain, pwalletIn, std::placeholders::_1));
+    g_signals.Inventory.connect(boost::bind(&CWalletInterface::Inventory, pwalletIn, std::placeholders::_1));
     g_signals.Broadcast.connect(boost::bind(&CWalletInterface::ResendWalletTransactions, pwalletIn));
 }
 
 void UnregisterWallet(CWalletInterface* pwalletIn) {
     g_signals.Broadcast.disconnect(boost::bind(&CWalletInterface::ResendWalletTransactions, pwalletIn));
-    g_signals.Inventory.disconnect(boost::bind(&CWalletInterface::Inventory, pwalletIn, _1));
-    g_signals.SetBestChain.disconnect(boost::bind(&CWalletInterface::SetBestChain, pwalletIn, _1));
-    g_signals.UpdatedTransaction.disconnect(boost::bind(&CWalletInterface::UpdatedTransaction, pwalletIn, _1));
-    g_signals.EraseTransaction.disconnect(boost::bind(&CWalletInterface::EraseFromWallet, pwalletIn, _1));
-    g_signals.SyncTransaction.disconnect(boost::bind(&CWalletInterface::SyncTransaction, pwalletIn, _1, _2, _3));
+    g_signals.Inventory.disconnect(boost::bind(&CWalletInterface::Inventory, pwalletIn, std::placeholders::_1));
+    g_signals.SetBestChain.disconnect(boost::bind(&CWalletInterface::SetBestChain, pwalletIn, std::placeholders::_1));
+    g_signals.UpdatedTransaction.disconnect(boost::bind(&CWalletInterface::UpdatedTransaction, pwalletIn, std::placeholders::_1));
+    g_signals.EraseTransaction.disconnect(boost::bind(&CWalletInterface::EraseFromWallet, pwalletIn, std::placeholders::_1));
+    g_signals.SyncTransaction.disconnect(boost::bind(&CWalletInterface::SyncTransaction, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 }
 
 void UnregisterAllWallets() {

--- a/src/qt/bitmarkgui.cpp
+++ b/src/qt/bitmarkgui.cpp
@@ -967,11 +967,11 @@ static bool ThreadSafeMessageBox(BitmarkGUI *gui, const std::string& message, co
 void BitmarkGUI::subscribeToCoreSignals()
 {
     // Connect signals to client
-    uiInterface.ThreadSafeMessageBox.connect(boost::bind(ThreadSafeMessageBox, this, _1, _2, _3));
+    uiInterface.ThreadSafeMessageBox.connect(boost::bind(ThreadSafeMessageBox, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 }
 
 void BitmarkGUI::unsubscribeFromCoreSignals()
 {
     // Disconnect signals from client
-    uiInterface.ThreadSafeMessageBox.disconnect(boost::bind(ThreadSafeMessageBox, this, _1, _2, _3));
+    uiInterface.ThreadSafeMessageBox.disconnect(boost::bind(ThreadSafeMessageBox, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 }

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -225,14 +225,14 @@ void ClientModel::subscribeToCoreSignals()
 {
     // Connect signals to client
     uiInterface.NotifyBlocksChanged.connect(boost::bind(NotifyBlocksChanged, this));
-    uiInterface.NotifyNumConnectionsChanged.connect(boost::bind(NotifyNumConnectionsChanged, this, _1));
-    uiInterface.NotifyAlertChanged.connect(boost::bind(NotifyAlertChanged, this, _1, _2));
+    uiInterface.NotifyNumConnectionsChanged.connect(boost::bind(NotifyNumConnectionsChanged, this, std::placeholders::_1));
+    uiInterface.NotifyAlertChanged.connect(boost::bind(NotifyAlertChanged, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 void ClientModel::unsubscribeFromCoreSignals()
 {
     // Disconnect signals from client
     uiInterface.NotifyBlocksChanged.disconnect(boost::bind(NotifyBlocksChanged, this));
-    uiInterface.NotifyNumConnectionsChanged.disconnect(boost::bind(NotifyNumConnectionsChanged, this, _1));
-    uiInterface.NotifyAlertChanged.disconnect(boost::bind(NotifyAlertChanged, this, _1, _2));
+    uiInterface.NotifyNumConnectionsChanged.disconnect(boost::bind(NotifyNumConnectionsChanged, this, std::placeholders::_1));
+    uiInterface.NotifyAlertChanged.disconnect(boost::bind(NotifyAlertChanged, this, std::placeholders::_1, std::placeholders::_2));
 }

--- a/src/qt/paymentrequestplus.cpp
+++ b/src/qt/paymentrequestplus.cpp
@@ -14,6 +14,7 @@
 
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
+#include <openssl/evp.h>
 #include <QDateTime>
 #include <QDebug>
 #include <QSslCertificate>
@@ -159,15 +160,16 @@ bool PaymentRequestPlus::getMerchant(X509_STORE* certStore, QString& merchant) c
         std::string data_to_verify;                     // Everything but the signature
         rcopy.SerializeToString(&data_to_verify);
 
-        EVP_MD_CTX ctx;
+        EVP_MD_CTX *ctx = EVP_MD_CTX_new();
         EVP_PKEY *pubkey = X509_get_pubkey(signing_cert);
-        EVP_MD_CTX_init(&ctx);
-        if (!EVP_VerifyInit_ex(&ctx, digestAlgorithm, NULL) ||
-            !EVP_VerifyUpdate(&ctx, data_to_verify.data(), data_to_verify.size()) ||
-            !EVP_VerifyFinal(&ctx, (const unsigned char*)paymentRequest.signature().data(), paymentRequest.signature().size(), pubkey)) {
+        if (!EVP_VerifyInit_ex(ctx, digestAlgorithm, NULL) ||
+            !EVP_VerifyUpdate(ctx, data_to_verify.data(), data_to_verify.size()) ||
+            !EVP_VerifyFinal(ctx, (const unsigned char*)paymentRequest.signature().data(), paymentRequest.signature().size(), pubkey)) {
 
+            EVP_MD_CTX_free(ctx);
             throw SSLVerifyError("Bad signature, invalid PaymentRequest.");
         }
+        EVP_MD_CTX_free(ctx);
 
         // OpenSSL API for getting human printable strings from certs is baroque.
         int textlen = X509_NAME_get_text_by_NID(certname, NID_commonName, NULL, 0);

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -124,25 +124,25 @@ static void ShowProgress(SplashScreen *splash, const std::string &title, int nPr
 #ifdef ENABLE_WALLET
 static void ConnectWallet(SplashScreen *splash, CWallet* wallet)
 {
-    wallet->ShowProgress.connect(boost::bind(ShowProgress, splash, _1, _2));
+    wallet->ShowProgress.connect(boost::bind(ShowProgress, splash, std::placeholders::_1, std::placeholders::_2));
 }
 #endif
 
 void SplashScreen::subscribeToCoreSignals()
 {
     // Connect signals to client
-    uiInterface.InitMessage.connect(boost::bind(InitMessage, this, _1));
+    uiInterface.InitMessage.connect(boost::bind(InitMessage, this, std::placeholders::_1));
 #ifdef ENABLE_WALLET
-    uiInterface.LoadWallet.connect(boost::bind(ConnectWallet, this, _1));
+    uiInterface.LoadWallet.connect(boost::bind(ConnectWallet, this, std::placeholders::_1));
 #endif
 }
 
 void SplashScreen::unsubscribeFromCoreSignals()
 {
     // Disconnect signals from client
-    uiInterface.InitMessage.disconnect(boost::bind(InitMessage, this, _1));
+    uiInterface.InitMessage.disconnect(boost::bind(InitMessage, this, std::placeholders::_1));
 #ifdef ENABLE_WALLET
     if(pwalletMain)
-        pwalletMain->ShowProgress.disconnect(boost::bind(ShowProgress, this, _1, _2));
+        pwalletMain->ShowProgress.disconnect(boost::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2));
 #endif
 }

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -7,6 +7,7 @@
 #include "clientmodel.h"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -500,19 +500,19 @@ static void ShowProgress(WalletModel *walletmodel, const std::string &title, int
 void WalletModel::subscribeToCoreSignals()
 {
     // Connect signals to wallet
-    wallet->NotifyStatusChanged.connect(boost::bind(&NotifyKeyStoreStatusChanged, this, _1));
-    wallet->NotifyAddressBookChanged.connect(boost::bind(NotifyAddressBookChanged, this, _1, _2, _3, _4, _5, _6));
-    wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
-    wallet->ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2));
+    wallet->NotifyStatusChanged.connect(boost::bind(&NotifyKeyStoreStatusChanged, this, std::placeholders::_1));
+    wallet->NotifyAddressBookChanged.connect(boost::bind(NotifyAddressBookChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6));
+    wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+    wallet->ShowProgress.connect(boost::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 void WalletModel::unsubscribeFromCoreSignals()
 {
     // Disconnect signals from wallet
-    wallet->NotifyStatusChanged.disconnect(boost::bind(&NotifyKeyStoreStatusChanged, this, _1));
-    wallet->NotifyAddressBookChanged.disconnect(boost::bind(NotifyAddressBookChanged, this, _1, _2, _3, _4, _5, _6));
-    wallet->NotifyTransactionChanged.disconnect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
-    wallet->ShowProgress.disconnect(boost::bind(ShowProgress, this, _1, _2));
+    wallet->NotifyStatusChanged.disconnect(boost::bind(&NotifyKeyStoreStatusChanged, this, std::placeholders::_1));
+    wallet->NotifyAddressBookChanged.disconnect(boost::bind(NotifyAddressBookChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6));
+    wallet->NotifyTransactionChanged.disconnect(boost::bind(NotifyTransactionChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+    wallet->ShowProgress.disconnect(boost::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 // WalletModel::UnlockContext implementation

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1135,31 +1135,16 @@ int RaiseFileDescriptorLimit(int nMinFD) {
 #else
     struct rlimit limitFD;
     if (getrlimit(RLIMIT_NOFILE, &limitFD) != -1) {
-        // first request at least the amount passed in
         if (limitFD.rlim_cur < (rlim_t)nMinFD) {
             limitFD.rlim_cur = nMinFD;
             if (limitFD.rlim_cur > limitFD.rlim_max)
                 limitFD.rlim_cur = limitFD.rlim_max;
             setrlimit(RLIMIT_NOFILE, &limitFD);
+            getrlimit(RLIMIT_NOFILE, &limitFD);
         }
-        // then try to raise to the max we can
-        if (limitFD.rlim_cur < limitFD.rlim_max) {
-            limitFD.rlim_cur = limitFD.rlim_max;
-            setrlimit(RLIMIT_NOFILE, &limitFD);
-        }
-
-        if (getrlimit(RLIMIT_NOFILE, &limitFD) != -1) {
-            if (limitFD.rlim_cur < (rlim_t)nMinFD) {
-                LogPrintf("RaiseFileDescriptorLimit: could not raise limit to %lu fds, only %lu\n",
-                          (unsigned long)nMinFD,
-                          (unsigned long)limitFD.rlim_cur);
-            }
-            return limitFD.rlim_cur;
-        }
+        return limitFD.rlim_cur;
     }
-    LogPrintf("RaiseFileDescriptorLimit error: getrlimit(RLIMIT_NOFILE) returned %s\n", strerror(errno));
-
-    return nMinFD; // getrlimit failed, try to proceed
+    return nMinFD; // getrlimit failed, assume it's fine
 #endif
 }
 


### PR DESCRIPTION
These changes make Bitmark code compilable using GCC 10 and Apple clang version 12.0.5, with Qt 5.15 & Openssl 1.1.1k.
Also fixes stack overflow in slow hash implementation on macOS 11 running on ARM64 and error message "Not enough file descriptors available."
